### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/chriskyfung/gmail-regex-cleaner-apps-script/security/code-scanning/8](https://github.com/chriskyfung/gmail-regex-cleaner-apps-script/security/code-scanning/8)

The recommended way to fix this issue is to add a `permissions:` block with least-privilege settings at the top level of the workflow. Since none of the steps in the provided snippet require write access—no pushes, PRs, or issue modifications are performed—the minimal recommended permission is `contents: read`. Place this `permissions:` block at the root of the workflow file, just after the workflow's `name` field, so it applies to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
